### PR TITLE
Fixed counter hit crash

### DIFF
--- a/objects/oglobalvars/Create_0.gml
+++ b/objects/oglobalvars/Create_0.gml
@@ -2121,9 +2121,9 @@ global.stBeverlyMoves = {
 			airKnockbackV: [0,-2],
 			airKnockbackH: [0,4],
 			
-			launches: [true],
-			LaunchKnockbackV: [0,-1],
-			LaunchKnockbackH: [0,5],
+			launches: [false,true],
+			LaunchKnockbackV: [0,-3],
+			LaunchKnockbackH: [0,0],
 			pushback: [1,3],
 			
 			particlexOffset : [18,18],


### PR DESCRIPTION
Fixed the crash that happened when landing a counter hit with the second hit of Bev's 2H. the counter hit has also had an adjustment in it's launch