### PR TITLE
Bev normals adjustments

### DIFF
--- a/datafiles/characterdata/Beverly.json
+++ b/datafiles/characterdata/Beverly.json
@@ -1887,17 +1887,17 @@
         {
           "Start": 4,
           "Lifetime": 5,
-          "AttackWidth": 15,
-          "AttackHeight": 5,
-          "WidthOffset": 12,
-          "HeightOffset": 15,
+          "AttackWidth": 16,
+          "AttackHeight": 12,
+          "WidthOffset": 7,
+          "HeightOffset": 9,
           "Group": 1,
           "Damage": 3,
           "AttackHitStop": 6,
           "AttackHitStun": 9,
           "AttackType": 1,
           "BlockStun": 3.0,
-          "KnockBack": 2.0,
+          "KnockBack": 2.5,
           "AirKnockbackVertical": 0.0,
           "AirKnockbackHorizontal": 1.0,
           "Launches": false,
@@ -1950,10 +1950,10 @@
         {
           "Start": 3,
           "Lifetime": 6,
-          "AttackWidth": 20,
-          "AttackHeight": 6,
-          "WidthOffset": 4,
-          "HeightOffset": 12
+          "AttackWidth": 14,
+          "AttackHeight": 9,
+          "WidthOffset": 7,
+          "HeightOffset": 8
         }
       ],
       "NumberOfProjectiles": 0,
@@ -1980,9 +1980,9 @@
     {
       "UID": "39969ce0-55a8-4628-a404-8492204900e1",
       "MoveType": 64,
-      "MoveCanCancelInto": 199064,
+      "MoveCanCancelInto": 199576,
       "SpriteName": "sBeverly_StandLight2_MOCKUP_strip3",
-      "Duration": 14,
+      "Duration": 15,
       "NumberOfFrames": 3,
       "FrameData": [
         {
@@ -2003,17 +2003,17 @@
         {
           "Start": 4,
           "Lifetime": 4,
-          "AttackWidth": 18,
+          "AttackWidth": 19,
           "AttackHeight": 13,
           "WidthOffset": 6,
           "HeightOffset": 0,
           "Group": 1,
           "Damage": 3,
-          "AttackHitStop": 10,
-          "AttackHitStun": 14,
+          "AttackHitStop": 9,
+          "AttackHitStun": 11,
           "AttackType": 1,
-          "BlockStun": 9.0,
-          "KnockBack": 2.0,
+          "BlockStun": 10.0,
+          "KnockBack": 1.0,
           "AirKnockbackVertical": 0.0,
           "AirKnockbackHorizontal": 1.0,
           "Launches": false,
@@ -2080,11 +2080,18 @@
         "HitOnFrames": []
       },
       "GroundMovementData": {
-        "NumberOfWindows": 1,
+        "NumberOfWindows": 2,
         "Windows": [
           {
             "StartingFrame": 0,
-            "HorizontalSpeed": 1.0,
+            "HorizontalSpeed": 1.0000001,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          },
+          {
+            "StartingFrame": 8,
+            "HorizontalSpeed": 0.0,
             "VerticalSpeed": 0.0,
             "OverwriteVerticalSpeed": false,
             "OverwriteHorizontalSpeed": true
@@ -2125,25 +2132,25 @@
       "NumberOfHitboxes": 1,
       "AttackData": [
         {
-          "Start": 6,
+          "Start": 4,
           "Lifetime": 3,
-          "AttackWidth": 22,
+          "AttackWidth": 27,
           "AttackHeight": 10,
-          "WidthOffset": 8,
+          "WidthOffset": 3,
           "HeightOffset": 15,
           "Group": 1,
           "Damage": 3,
           "AttackHitStop": 14,
           "AttackHitStun": 14,
           "AttackType": 1,
-          "BlockStun": 9.0,
+          "BlockStun": 11.0,
           "KnockBack": 0.0,
           "AirKnockbackVertical": 0.0,
           "AirKnockbackHorizontal": 1.0,
           "Launches": true,
           "LaunchKnockbackVertical": 1.0,
-          "LaunchKnockbackHorizontal": 3.0,
-          "Pushback": 2.0,
+          "LaunchKnockbackHorizontal": 3.4999995,
+          "Pushback": 1.9999999,
           "ParticleXOffset": 10,
           "ParticleYOffset": 0,
           "ParticleEffect": "sHitEffect",
@@ -2188,7 +2195,7 @@
       "NumberOfHurtboxes": 1,
       "HurtboxData": [
         {
-          "Start": 6,
+          "Start": 4,
           "Lifetime": 8,
           "AttackWidth": 22,
           "AttackHeight": 9,
@@ -2204,8 +2211,23 @@
         "HitOnFrames": []
       },
       "GroundMovementData": {
-        "NumberOfWindows": 0,
-        "Windows": [],
+        "NumberOfWindows": 2,
+        "Windows": [
+          {
+            "StartingFrame": 0,
+            "HorizontalSpeed": 0.6,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": false
+          },
+          {
+            "StartingFrame": 7,
+            "HorizontalSpeed": 0.0,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          }
+        ],
         "GravityScale": 0.0,
         "FallScale": 0.0
       },
@@ -2253,21 +2275,21 @@
           "Lifetime": 4,
           "AttackWidth": 23,
           "AttackHeight": 8,
-          "WidthOffset": 10,
-          "HeightOffset": 10,
+          "WidthOffset": 12,
+          "HeightOffset": 14,
           "Group": 1,
           "Damage": 6,
           "AttackHitStop": 11,
           "AttackHitStun": 21,
           "AttackType": 1,
-          "BlockStun": 16.0,
+          "BlockStun": 15.0,
           "KnockBack": 4.0,
           "AirKnockbackVertical": -2.0,
           "AirKnockbackHorizontal": 2.0,
           "Launches": false,
           "LaunchKnockbackVertical": 0.0,
           "LaunchKnockbackHorizontal": 0.0,
-          "Pushback": 2.0,
+          "Pushback": 2.6999998,
           "ParticleXOffset": 10,
           "ParticleYOffset": 0,
           "ParticleEffect": "sHitEffect",
@@ -2312,12 +2334,12 @@
       "NumberOfHurtboxes": 1,
       "HurtboxData": [
         {
-          "Start": 5,
-          "Lifetime": 13,
-          "AttackWidth": 22,
-          "AttackHeight": 6,
-          "WidthOffset": 4,
-          "HeightOffset": 10
+          "Start": 6,
+          "Lifetime": 8,
+          "AttackWidth": 27,
+          "AttackHeight": 8,
+          "WidthOffset": 5,
+          "HeightOffset": 14
         }
       ],
       "NumberOfProjectiles": 0,
@@ -2368,7 +2390,7 @@
       "MoveType": 512,
       "MoveCanCancelInto": 196632,
       "SpriteName": "sBeverly_StandHeavy_MOCKUP_strip5",
-      "Duration": 39,
+      "Duration": 40,
       "NumberOfFrames": 5,
       "FrameData": [
         {
@@ -2395,25 +2417,25 @@
       "NumberOfHitboxes": 1,
       "AttackData": [
         {
-          "Start": 12,
+          "Start": 14,
           "Lifetime": 5,
-          "AttackWidth": 30,
-          "AttackHeight": 20,
+          "AttackWidth": 29,
+          "AttackHeight": 18,
           "WidthOffset": -1,
-          "HeightOffset": 0,
+          "HeightOffset": 6,
           "Group": 1,
-          "Damage": 14,
-          "AttackHitStop": 18,
-          "AttackHitStun": 14,
+          "Damage": 15,
+          "AttackHitStop": 19,
+          "AttackHitStun": 15,
           "AttackType": 1,
-          "BlockStun": 20.0,
+          "BlockStun": 21.0,
           "KnockBack": 5.0,
           "AirKnockbackVertical": -2.0,
           "AirKnockbackHorizontal": 3.0,
           "Launches": true,
-          "LaunchKnockbackVertical": -1.0,
-          "LaunchKnockbackHorizontal": 3.0,
-          "Pushback": 3.0,
+          "LaunchKnockbackVertical": -1.3000001,
+          "LaunchKnockbackHorizontal": 1.8,
+          "Pushback": 2.7000003,
           "ParticleXOffset": 18,
           "ParticleYOffset": 10,
           "ParticleEffect": "sHitEffect",
@@ -2429,21 +2451,21 @@
         {
           "CounterHitLevel": 3,
           "Group": 1,
-          "Damage": 20,
+          "Damage": 23,
           "MeterGain": 12.0,
           "AttackHitStop": 30,
-          "AttackHitStun": 14,
+          "AttackHitStun": 18,
           "KnockBack": 5.0,
-          "AirKnockbackVertical": -2.0,
-          "AirKnockbackHorizontal": 4.0,
-          "Pushback": 0.0,
+          "AirKnockbackVertical": -3.0,
+          "AirKnockbackHorizontal": 4.5,
+          "Pushback": 5.0,
           "ParticleXOffset": 10,
           "ParticleYOffset": 18,
           "ParticleEffect": "sHitEffect",
           "ParticleDuration": 10,
           "Launches": true,
-          "LaunchKnockbackVertical": -1.0,
-          "LaunchKnockbackHorizontal": 5.0,
+          "LaunchKnockbackVertical": -2.0,
+          "LaunchKnockbackHorizontal": 4.0,
           "ComboScaling": 1.0,
           "CausesWallbounce": false
         }
@@ -2459,11 +2481,11 @@
       "HurtboxData": [
         {
           "Start": 12,
-          "Lifetime": 19,
-          "AttackWidth": 22,
-          "AttackHeight": 24,
+          "Lifetime": 6,
+          "AttackWidth": 29,
+          "AttackHeight": 18,
           "WidthOffset": -1,
-          "HeightOffset": 0
+          "HeightOffset": 6
         }
       ],
       "NumberOfProjectiles": 0,
@@ -2474,7 +2496,7 @@
         "HitOnFrames": []
       },
       "GroundMovementData": {
-        "NumberOfWindows": 3,
+        "NumberOfWindows": 7,
         "Windows": [
           {
             "StartingFrame": 0,
@@ -2484,17 +2506,45 @@
             "OverwriteHorizontalSpeed": true
           },
           {
-            "StartingFrame": 12,
-            "HorizontalSpeed": 12.0,
+            "StartingFrame": 5,
+            "HorizontalSpeed": 0.5,
             "VerticalSpeed": 0.0,
             "OverwriteVerticalSpeed": true,
             "OverwriteHorizontalSpeed": true
           },
           {
-            "StartingFrame": 13,
+            "StartingFrame": 8,
+            "HorizontalSpeed": 0.5,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          },
+          {
+            "StartingFrame": 9,
+            "HorizontalSpeed": 1.0,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          },
+          {
+            "StartingFrame": 11,
+            "HorizontalSpeed": 9.0,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          },
+          {
+            "StartingFrame": 14,
+            "HorizontalSpeed": 0.5,
+            "VerticalSpeed": 0.0,
+            "OverwriteVerticalSpeed": false,
+            "OverwriteHorizontalSpeed": true
+          },
+          {
+            "StartingFrame": 15,
             "HorizontalSpeed": 0.0,
             "VerticalSpeed": 0.0,
-            "OverwriteVerticalSpeed": true,
+            "OverwriteVerticalSpeed": false,
             "OverwriteHorizontalSpeed": true
           }
         ],
@@ -2514,7 +2564,7 @@
       "MoveType": 1024,
       "MoveCanCancelInto": 198936,
       "SpriteName": "sBeverly_CrouchLight_MOCKUP_strip4",
-      "Duration": 9,
+      "Duration": 10,
       "NumberOfFrames": 4,
       "FrameData": [
         {
@@ -2537,9 +2587,9 @@
       "NumberOfHitboxes": 1,
       "AttackData": [
         {
-          "Start": 4,
+          "Start": 5,
           "Lifetime": 2,
-          "AttackWidth": 16,
+          "AttackWidth": 22,
           "AttackHeight": 5,
           "WidthOffset": 8,
           "HeightOffset": 0,
@@ -2602,7 +2652,7 @@
         {
           "Start": 4,
           "Lifetime": 4,
-          "AttackWidth": 21,
+          "AttackWidth": 22,
           "AttackHeight": 8,
           "WidthOffset": 4,
           "HeightOffset": 0
@@ -2634,7 +2684,7 @@
       "MoveType": 2048,
       "MoveCanCancelInto": 201240,
       "SpriteName": "sBeverly_CrouchMedium_MOCKUP_strip4",
-      "Duration": 24,
+      "Duration": 26,
       "NumberOfFrames": 4,
       "FrameData": [
         {
@@ -2657,19 +2707,19 @@
       "NumberOfHitboxes": 1,
       "AttackData": [
         {
-          "Start": 7,
+          "Start": 9,
           "Lifetime": 2,
-          "AttackWidth": 18,
+          "AttackWidth": 28,
           "AttackHeight": 10,
-          "WidthOffset": 13,
+          "WidthOffset": 11,
           "HeightOffset": 0,
           "Group": 1,
-          "Damage": 10,
+          "Damage": 8,
           "AttackHitStop": 11,
           "AttackHitStun": 18,
           "AttackType": 2,
-          "BlockStun": 12.0,
-          "KnockBack": 4.0,
+          "BlockStun": 10.0,
+          "KnockBack": 3.0,
           "AirKnockbackVertical": 1.0,
           "AirKnockbackHorizontal": 1.0,
           "Launches": false,
@@ -2717,13 +2767,21 @@
         "NumberOfFrames": 0,
         "Frames": []
       },
-      "NumberOfHurtboxes": 1,
+      "NumberOfHurtboxes": 2,
       "HurtboxData": [
         {
           "Start": 5,
-          "Lifetime": 13,
-          "AttackWidth": 15,
-          "AttackHeight": 10,
+          "Lifetime": 5,
+          "AttackWidth": 28,
+          "AttackHeight": 11,
+          "WidthOffset": 4,
+          "HeightOffset": 0
+        },
+        {
+          "Start": 10,
+          "Lifetime": 3,
+          "AttackWidth": 20,
+          "AttackHeight": 11,
           "WidthOffset": 4,
           "HeightOffset": 0
         }
@@ -2798,23 +2856,23 @@
       "AttackData": [
         {
           "Start": 8,
-          "Lifetime": 1,
-          "AttackWidth": 30,
+          "Lifetime": 2,
+          "AttackWidth": 29,
           "AttackHeight": 5,
           "WidthOffset": 8,
           "HeightOffset": 0,
           "Group": 1,
-          "Damage": 4,
+          "Damage": 3,
           "AttackHitStop": 14,
           "AttackHitStun": 11,
           "AttackType": 2,
           "BlockStun": 8.0,
-          "KnockBack": 0.0,
+          "KnockBack": -2.0,
           "AirKnockbackVertical": -1.0,
           "AirKnockbackHorizontal": 0.0,
-          "Launches": false,
-          "LaunchKnockbackVertical": 0.0,
-          "LaunchKnockbackHorizontal": 0.0,
+          "Launches": true,
+          "LaunchKnockbackVertical": -1.0,
+          "LaunchKnockbackHorizontal": -2.0,
           "Pushback": 1.0,
           "ParticleXOffset": 20,
           "ParticleYOffset": 20,
@@ -2829,22 +2887,22 @@
         {
           "Start": 11,
           "Lifetime": 2,
-          "AttackWidth": 30,
-          "AttackHeight": 5,
+          "AttackWidth": 29,
+          "AttackHeight": 7,
           "WidthOffset": 8,
           "HeightOffset": 0,
           "Group": 2,
-          "Damage": 5,
+          "Damage": 9,
           "AttackHitStop": 14,
           "AttackHitStun": 11,
           "AttackType": 2,
-          "BlockStun": 8.0,
+          "BlockStun": 9.0,
           "KnockBack": 2.0,
           "AirKnockbackVertical": -2.0,
-          "AirKnockbackHorizontal": 1.0,
+          "AirKnockbackHorizontal": 1.5,
           "Launches": true,
           "LaunchKnockbackVertical": -1.0,
-          "LaunchKnockbackHorizontal": 1.0,
+          "LaunchKnockbackHorizontal": 1.5,
           "Pushback": 4.0,
           "ParticleXOffset": 20,
           "ParticleYOffset": 10,
@@ -2852,7 +2910,7 @@
           "ParticleDuration": 5,
           "HoldXOffset": 0,
           "HoldYOffset": 0,
-          "MeterGain": 8.0,
+          "MeterGain": 6.0,
           "ComboScaling": 2.0,
           "CausesWallbounce": false
         }
@@ -2861,7 +2919,7 @@
         {
           "CounterHitLevel": 3,
           "Group": 1,
-          "Damage": 10,
+          "Damage": 6,
           "MeterGain": 7.0,
           "AttackHitStop": 20,
           "AttackHitStun": 14,
@@ -2882,7 +2940,7 @@
         {
           "CounterHitLevel": 3,
           "Group": 2,
-          "Damage": 20,
+          "Damage": 11,
           "MeterGain": 8.0,
           "AttackHitStop": 20,
           "AttackHitStun": 25,
@@ -3645,7 +3703,7 @@
           "WidthOffset": 0,
           "HeightOffset": 2,
           "Group": 1,
-          "Damage": 15,
+          "Damage": 10,
           "AttackHitStop": 10,
           "AttackHitStun": 19,
           "AttackType": 1,
@@ -3675,7 +3733,7 @@
           "WidthOffset": -28,
           "HeightOffset": 2,
           "Group": 1,
-          "Damage": 15,
+          "Damage": 10,
           "AttackHitStop": 10,
           "AttackHitStun": 19,
           "AttackType": 1,
@@ -3806,6 +3864,6 @@
   ],
   "Version": "Ver1.1.0",
   "UID": "eb11e2fc-bf4d-45e7-88d0-10fe49d121d8",
-  "LastModified": "2023-05-18T16:51:33.6435838-07:00",
-  "LastModifiedBy": "iansb"
+  "LastModified": "2023-05-25T19:16:41.2638158-07:00",
+  "LastModifiedBy": "alarb"
 }

--- a/datafiles/characterdata/Beverly.json
+++ b/datafiles/characterdata/Beverly.json
@@ -2621,11 +2621,11 @@
         {
           "CounterHitLevel": 1,
           "Group": 1,
-          "Damage": 20,
+          "Damage": 6,
           "MeterGain": 12.0,
           "AttackHitStop": 30,
           "AttackHitStun": 14,
-          "KnockBack": 5.0,
+          "KnockBack": 2.0,
           "AirKnockbackVertical": -2.0,
           "AirKnockbackHorizontal": 4.0,
           "Pushback": 0.0,
@@ -3864,6 +3864,6 @@
   ],
   "Version": "Ver1.1.0",
   "UID": "eb11e2fc-bf4d-45e7-88d0-10fe49d121d8",
-  "LastModified": "2023-05-25T19:16:41.2638158-07:00",
+  "LastModified": "2023-05-25T19:22:28.6902159-07:00",
   "LastModifiedBy": "alarb"
 }


### PR DESCRIPTION
**sL1-3 series adjusted primarily to be good at reclaiming space rather than applying pressure

sL1
-minor hitbox and hurtbox adjustments
-increased knockback
*sL1 is +1 on block meaning its a very solid mash option

sL2
!- can now be cancelled into sH; not a true combo
-minor hitbox and hurtbox adjustments
-less hit stun
-less knockback
-made horizontal speed a feature rather than a bug; speed looks a lot less janky
*sL2 now lets you make the decision of going into sL3, sM, or sH.
*sL3 is true and gets you more space & knockdown, sM is true and gets you more damage, sH is NOT true but is a solid frame trap

sL3
-minor hitbox and hurtbox adjustments
-minor adjustments to frame data to make the move feel better; no effect in practice
-is now -7 on block instead of -9; in line with russel's auto combo
-slightly more knockback on hit

sM
-minor hitbox and hurtbox adjustments
-decreased blockstun; now +1 on block instead of +2
-increased pushback on block
*now better as the poke its meant to be

sH
-hitbox and hurtbox adjustments
-motion adjusted to be more fluid
-increased damage 14->15
-slower startup 12f->14f
-recovery 39->40
-hitstun 14->15
-blockstun 20->21
*slightly worse on whiff but same on hit and block
-decreased pushback on block
-decreased knockback
-counterhit now has stronger knockback & damage
*feels much better to use overall. 
*hurtbox shape can avoid sweeps at specific ranges. unintentional but cool. can fix, play around with it a bit and see if you like it

cL
-minor hitbox and hurtbox adjustments
-adjusted startup 4f->5f

cM
-hitbox and hurtbox adjustments
!* now the furthest reaching normal instead of the second shortest
-startup 7f->9f
-damage 10->8
-decreased blockstun
-decreased knockback
-increased recovery time
-hurtbox now retracts slightly as move finishes
*these read like major nerfs but the move feels stronger due to range

cH
!- first hit now vortexes slightly
*makes the second hit consistent and also means the first hit can special cancel in interesting ways
-hits slightly more active (1f->2f)
-second hit slightly more blockstun (8f->9f)
-second increased knockback
-reduced meter gain
-slightly reduced range
-damage changed from 5,5 to 3,9
-counter hit no longer deals an absurd 30 damage

down special
-damage 15->10
*just seemed a little crazy in testing. move needs closer look but im mostly just working with normals right now